### PR TITLE
Export the BankTransferRequest fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,3 @@ module github.com/wirepay/maplerad-go
 go 1.18
 
 require github.com/mitchellh/mapstructure v1.5.0
-
-require (
-	github.com/go-resty/resty/v2 v2.7.0 // indirect
-	golang.org/x/net v0.0.0-20211029224645-99673261e6eb // indirect
-)

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,2 @@
-github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
-github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-golang.org/x/net v0.0.0-20211029224645-99673261e6eb h1:pirldcYWx7rx7kE5r+9WsOXPXK0+WH5+uZ7uPmJ44uM=
-golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/lib/maplerad.go
+++ b/lib/maplerad.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"github.com/wirepay/maplerad-go/utils"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -155,7 +154,7 @@ func (c *Client) decodeResponse(httpResp *http.Response, v interface{}) error {
 	if httpResp.StatusCode >= 400 {
 		return utils.NewAPIError(httpResp)
 	}
-	respBody, err := ioutil.ReadAll(httpResp.Body)
+	respBody, err := io.ReadAll(httpResp.Body)
 	err = json.Unmarshal(respBody, &v)
 	if err != nil {
 		return err

--- a/lib/transfer.go
+++ b/lib/transfer.go
@@ -9,15 +9,15 @@ import (
 type TransferService service
 
 type BankTransferRequest struct {
-	bankCode      string
-	amount        string
-	accountNumber string
-	currency      utils.CurrencySymbol
+	BankCode      string
+	Amount        string
+	AccountNumber string
+	Currency      utils.CurrencySymbol
 }
 
 func (c *TransferService) NigerianBankTransfer(body *BankTransferRequest) (*models.NigerianBankTransferResponse, error) {
 	u := "/transfers"
-	body.currency = "NGN"
+	body.Currency = "NGN"
 	resp := &models.NigerianBankTransferResponse{}
 	err := c.client.Call("POST", u, nil, body, &resp)
 	return resp, err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"github.com/mitchellh/mapstructure"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -48,7 +48,7 @@ type ErrorResponse struct {
 }
 
 func NewAPIError(resp *http.Response) *APIError {
-	p, _ := ioutil.ReadAll(resp.Body)
+	p, _ := io.ReadAll(resp.Body)
 
 	var mapleradErrorResp ErrorResponse
 	_ = json.Unmarshal(p, &mapleradErrorResp)


### PR DESCRIPTION
This PR does the following 

- Exports the BankTransferRequest fields
- Remove the deprecated ioutil package

Justification:
The ioutil package has been deprecated and replaced with the io package. 
The BankTransferRequest fields is unavailable outside the lib package and makes this unusable